### PR TITLE
error handling for wrong ID

### DIFF
--- a/src/GNDShowHooks.php
+++ b/src/GNDShowHooks.php
@@ -67,7 +67,7 @@ class GNDShowHooks
         //Param1 represents the wikidata-id
 
         global $wgScriptPath;
-        global $wgDockerServer;
+        global $wgServer;
 
         $gnd = "";
 
@@ -84,7 +84,7 @@ class GNDShowHooks
             // get wikidatalink from actual page
             if (empty($param2)) { // if param2 is not set, take the wikidatalink from the actual page
 
-                $endpoint = "$wgDockerServer$wgScriptPath/api.php";
+                $endpoint = "$wgServer$wgScriptPath/api.php";
                 $url = "$endpoint?action=ask&query=[[$titleunderscores]]|?Wikidata_ID|limit=5&format=json";
                 $json_data = file_get_contents($url);
                 $apiresponse = json_decode($json_data, true);

--- a/src/GNDShowHooks.php
+++ b/src/GNDShowHooks.php
@@ -234,7 +234,7 @@ class GNDShowHooks
                 }
             } catch (Exception $e) {
                 $GLOBALS["bbfOutput"] = "wrong BBF URN";
-                return "wrong BBF URN";
+                return $e->getMessage();
             }
             
         }

--- a/src/GNDShowHooks.php
+++ b/src/GNDShowHooks.php
@@ -26,50 +26,42 @@ class GNDShowHooks
 
             $refResult = "";
             
-            try {
-                if (empty($xmlRef->records->record->recordData)) {
-                    throw new Exception('not defined');
-                } else {
 
-                    foreach ($xmlRef->records->record as $record) {
+            foreach ($xmlRef->records->record as $record) {
 
-                        $ns_dc = $record->recordData->dc->children($ns['dc']);
-        
-                        $record_title = strval($ns_dc->title);
-                        $record_creator = strval($ns_dc->creator);
-                        $record_date = strval($ns_dc->date);
-        
-                        foreach ($ns_dc->identifier as $identifier) {
-                            if ($identifier->attributes("xsi", TRUE)->type == "dnb:IDN") {
-                                $record_idn = strval(strval($ns_dc->identifier));
-                            }
-                        }
-        
-                        $record_url = "http://d-nb.info/" . $record_idn;
-        
-                        // check on doublettes - if not, catch this object
-                        if (in_array($record_idn, $refIdns) !== true) {
-        
-                            array_push($refIdns, $record_idn);
-        
-                            $refResult = $refResult . "
-                                    |$record_title
-                                    |$record_creator
-                                    |$record_date
-                                    |$record_url
-                                    |-
-                                ";
-                        }
+                $ns_dc = $record->recordData->dc->children($ns['dc']);
+
+                $record_title = strval($ns_dc->title);
+                $record_creator = strval($ns_dc->creator);
+                $record_date = strval($ns_dc->date);
+
+                foreach ($ns_dc->identifier as $identifier) {
+                    if ($identifier->attributes("xsi", TRUE)->type == "dnb:IDN") {
+                        $record_idn = strval(strval($ns_dc->identifier));
                     }
-        
-                    $GLOBALS["output"] = $GLOBALS["output"] . $refResult;
-        
-                    return $refIdns;
+                }
+
+                $record_url = "http://d-nb.info/" . $record_idn;
+
+                // check on doublettes - if not, catch this object
+                if (in_array($record_idn, $refIdns) !== true) {
+
+                    array_push($refIdns, $record_idn);
+
+                    $refResult = $refResult . "
+                            |$record_title
+                            |$record_creator
+                            |$record_date
+                            |$record_url
+                            |-
+                        ";
                 }
             }
-            catch (Exception $e) {
-                return "wrong DNB IDN";
-            }            
+
+            $GLOBALS["output"] = $GLOBALS["output"] . $refResult;
+
+            return $refIdns;
+                      
         }
 
         //Param1 represents the wikidata-id
@@ -241,6 +233,7 @@ class GNDShowHooks
                     return $bbfRefIdns;
                 }
             } catch (Exception $e) {
+                $GLOBALS["bbfOutput"] = "wrong BBF URN";
                 return "wrong BBF URN";
             }
             

--- a/src/GNDShowHooks.php
+++ b/src/GNDShowHooks.php
@@ -25,41 +25,48 @@ class GNDShowHooks
             $ns = $xmlRef->getNamespaces(true);
 
             $refResult = "";
+            
+            try {
 
-            foreach ($xmlRef->records->record as $record) {
+                foreach ($xmlRef->records->record as $record) {
 
-                $ns_dc = $record->recordData->dc->children($ns['dc']);
-
-                $record_title = strval($ns_dc->title);
-                $record_creator = strval($ns_dc->creator);
-                $record_date = strval($ns_dc->date);
-
-                foreach ($ns_dc->identifier as $identifier) {
-                    if ($identifier->attributes("xsi", TRUE)->type == "dnb:IDN") {
-                        $record_idn = strval(strval($ns_dc->identifier));
+                    $ns_dc = $record->recordData->dc->children($ns['dc']);
+    
+                    $record_title = strval($ns_dc->title);
+                    $record_creator = strval($ns_dc->creator);
+                    $record_date = strval($ns_dc->date);
+    
+                    foreach ($ns_dc->identifier as $identifier) {
+                        if ($identifier->attributes("xsi", TRUE)->type == "dnb:IDN") {
+                            $record_idn = strval(strval($ns_dc->identifier));
+                        }
+                    }
+    
+                    $record_url = "http://d-nb.info/" . $record_idn;
+    
+                    // check on doublettes - if not, catch this object
+                    if (in_array($record_idn, $refIdns) !== true) {
+    
+                        array_push($refIdns, $record_idn);
+    
+                        $refResult = $refResult . "
+                                |$record_title
+                                |$record_creator
+                                |$record_date
+                                |$record_url
+                                |-
+                            ";
                     }
                 }
+    
+                $GLOBALS["output"] = $GLOBALS["output"] . $refResult;
+    
+                return $refIdns;
 
-                $record_url = "http://d-nb.info/" . $record_idn;
-
-                // check on doublettes - if not, catch this object
-                if (in_array($record_idn, $refIdns) !== true) {
-
-                    array_push($refIdns, $record_idn);
-
-                    $refResult = $refResult . "
-                            |$record_title
-                            |$record_creator
-                            |$record_date
-                            |$record_url
-                            |-
-                        ";
-                }
             }
-
-            $GLOBALS["output"] = $GLOBALS["output"] . $refResult;
-
-            return $refIdns;
+            catch (Exception $e) {
+                return "wrong DNB IDN";
+            }            
         }
 
         //Param1 represents the wikidata-id
@@ -133,47 +140,54 @@ class GNDShowHooks
 
         // get DNB-IDN in oai_dc: separate dc:identifier with xsi:type="dnb:IDN"
 
-        foreach ($xml_idn->records->record->recordData->dc as $record) {
+        try {
 
-            $ns_dc = $record->children($ns['dc']);
+            foreach ($xml_idn->records->record->recordData->dc as $record) {
 
-            // $ns_xsi = $ns_dc->children['http://www.w3.org/2001/XMLSchema-instance'];
-
-            // if (trim($ns_xsi->identifier['type'] == "dnb:IDN")) {
-
-            foreach ($ns_dc->identifier as $identifier) {
-                if ($identifier->attributes("xsi", TRUE)->type == "dnb:IDN") {
-                    $idn = strval(strval($ns_dc->identifier));
+                $ns_dc = $record->children($ns['dc']);
+    
+                // $ns_xsi = $ns_dc->children['http://www.w3.org/2001/XMLSchema-instance'];
+    
+                // if (trim($ns_xsi->identifier['type'] == "dnb:IDN")) {
+    
+                foreach ($ns_dc->identifier as $identifier) {
+                    if ($identifier->attributes("xsi", TRUE)->type == "dnb:IDN") {
+                        $idn = strval(strval($ns_dc->identifier));
+                    }
                 }
+    
             }
+    
+            global $output;
+    
+            // Prepared Output base
+            $output = "
+                {| class='wikitable'
+                !Titel
+                !Verfasser:in
+                !Datum
+                !Quelle
+                |-
+                ";
+    
+            // Collection of fetched publication IDNs to prevent doublettes, used as return value to pass it with every ref-data-fetch
+            $refIdns = array();
+    
+            // #2 Getting the auRef-Data by DNB-IDN
+            $refIdns = getDNBref("auRef", $idn, $refIdns);
+    
+            // #3 Getting the betRef-Data by DNB-IDN
+            $refIdns = getDNBref("betRef", $idn, $refIdns);
+    
+            // #4 Getting the swiRef-Data by DNB-IDN
+            $refIdns = getDNBref("swiRef", $idn, $refIdns);
+    
+            return $output;
 
+        } catch (Exception $e) {
+            return "wrong GND ID";
         }
 
-        global $output;
-
-        // Prepared Output base
-        $output = "
-            {| class='wikitable'
-            !Titel
-            !Verfasser:in
-            !Datum
-            !Quelle
-            |-
-            ";
-
-        // Collection of fetched publication IDNs to prevent doublettes, used as return value to pass it with every ref-data-fetch
-        $refIdns = array();
-
-        // #2 Getting the auRef-Data by DNB-IDN
-        $refIdns = getDNBref("auRef", $idn, $refIdns);
-
-        // #3 Getting the betRef-Data by DNB-IDN
-        $refIdns = getDNBref("betRef", $idn, $refIdns);
-
-        // #4 Getting the swiRef-Data by DNB-IDN
-        $refIdns = getDNBref("swiRef", $idn, $refIdns);
-
-        return $output;
     }
 
     // get bbf data by manually given on edit Wiki page
@@ -192,30 +206,36 @@ class GNDShowHooks
             $ns = $xmlRef->getNamespaces(true);
    
             $refResult = "";
+            try {
 
-            $metadata = $xmlRef->GetRecord->record->metadata;
-            $ns_oaidc = $metadata->children($ns['oai_dc']);
-            $oaidc = $ns_oaidc->dc;
-            $ns_dc = $oaidc->children($ns['dc']);
+                $metadata = $xmlRef->GetRecord->record->metadata;
+                $ns_oaidc = $metadata->children($ns['oai_dc']);
+                $oaidc = $ns_oaidc->dc;
+                $ns_dc = $oaidc->children($ns['dc']);
 
-            $record_title = strval($ns_dc->title);            
-            $record_date = strval($ns_dc->date);
-            $record_desc = strval($ns_dc->source);
-            $record_url = strval($ns_dc->identifier);
+                $record_title = strval($ns_dc->title);            
+                $record_date = strval($ns_dc->date);
+                $record_desc = strval($ns_dc->source);
+                $record_url = strval($ns_dc->identifier);
 
-            $record_desc = "'". $record_desc . "'";
+                $record_desc = "'". $record_desc . "'";
 
-            $refResult = $refResult . "
-                    |$record_title
-                    |$record_date
-                    |$record_url
-                    |$record_desc
-                    |-
-                ";
+                $refResult = $refResult . "
+                        |$record_title
+                        |$record_date
+                        |$record_url
+                        |$record_desc
+                        |-
+                    ";
 
-            $GLOBALS["bbfOutput"] = $GLOBALS["bbfOutput"] . $refResult;
+                $GLOBALS["bbfOutput"] = $GLOBALS["bbfOutput"] . $refResult;
 
-            return $bbfRefIdns;
+                return $bbfRefIdns;
+
+            } catch (Exception $e) {
+                return "wrong BBF URN";
+            }
+            
         }
 
         global $bbfOutput;

--- a/src/GNDShowHooks.php
+++ b/src/GNDShowHooks.php
@@ -144,7 +144,7 @@ class GNDShowHooks
         // get DNB-IDN in oai_dc: separate dc:identifier with xsi:type="dnb:IDN"
 
         try {
-            if (empty(xml_idn->records->record->recordData->dc)) {
+            if (empty($xml_idn->records->record->recordData->dc)) {
                 throw new Exception('not defined');
             } else {
                 foreach ($xml_idn->records->record->recordData->dc as $record) {


### PR DESCRIPTION
If you enter an incorrect GND ID or BBF URN, an output informs you of this at the corresponding place. If one of multiple BBF-URNs is wrong, the correct ones are ignored.
![image](https://user-images.githubusercontent.com/20246084/135615602-804ef060-a9c0-4a10-8561-7c787d0d88d2.png)